### PR TITLE
Param alias bugfix patch

### DIFF
--- a/badchars.py
+++ b/badchars.py
@@ -104,9 +104,18 @@ class BytesParser():
 
         if format:
             out(dbg("Using user-specified format: %s" % format))
-            assert format in BytesParser.formats_rex.keys(), \
+
+            try:
+                self.format = BytesParser.interpret_format_name(format)
+            except Exception:
+                out(dbg("alias not found: %s" % format))
+
+            assert (format in BytesParser.formats_rex.keys() or self.format is not None), \
                     "Format '%s' is not implemented." % format
-            self.format = format
+                    
+            if self.format is None:
+                self.format = format
+
         else:
             self.recognize_format()
 
@@ -133,7 +142,7 @@ class BytesParser():
 
     @staticmethod
     def interpret_format_name(name):
-        for k, v in BytesParser.formats_aliases:
+        for k, v in BytesParser.formats_aliases.items():
             if name.lower() in v:
                 return k
         raise Exception("Format name: %s not recognized as alias." % name)


### PR DESCRIPTION
<b>### Bug fix 1:</b>
<b>issue: </b>
badchar.py does not recognize alias as parameter for --format1, --format2

example,
```
root@kali:/tmp/expdevBadChars# python badchars.py --format1=gdb --format2=gdb ~/src ~/dest

        :: BadChars.py (v:0.2) - Exploit Development Bad Characters hunting tool.
                Equipped with Corelan.be Mona's buffers comparison LCS-based algorithm

Traceback (most recent call last):
  File "badchars.py", line 997, in <module>
    sys.exit(main(sys.argv))
  File "badchars.py", line 929, in main
    buffers[0].extend(fetch_file(filenames[0], 'good_buffer', options.format1))
  File "badchars.py", line 829, in fetch_file
    b = BytesParser(buff, name, format)
  File "badchars.py", line 108, in __init__
    "Format '%s' is not implemented." % format
AssertionError: Format 'gdb' is not implemented.
```

<b>###Bug fix 2:</b>
<b>issue:</b> badchar.py failed to <i>(1)automatically recognize</i> and <i>(2)parse</i> GDB hex format.  when presented with address header, the address header should be exclude from the badchar comparison.

Example:
<b>0xffffd67a:</b>     0xdfb8c2db      0xd9db029c      0x5bf42474      0x0bb1c933

The highlighted address should be excluded from the badchar comparison

