### PR TITLE
Origin/input format raw bugfix patch

### DIFF
--- a/badchars.py
+++ b/badchars.py
@@ -115,8 +115,8 @@ class BytesParser():
             else:		
                 try:
                     self.format = BytesParser.interpret_format_name(format)
-                except Exception:
-                    out(dbg("alias not found: %s" % format))
+                except Exception, e:
+                    out(dbg(str(e)))
 
                 #exit when user-specified format not in both formats_rex and formats_aliases 
                 assert (format in BytesParser.formats_rex.keys() or self.format is not None), \

--- a/badchars.py
+++ b/badchars.py
@@ -107,14 +107,18 @@ class BytesParser():
         if format:
             out(dbg("Using user-specified format: %s" % format))
 
-            try:
-                self.format = BytesParser.interpret_format_name(format)
-            except Exception:
-                out(dbg("alias not found: %s" % format))
+            if str(format).lower() == "raw":
+                self.format = "raw"
+                           
+            else:		
+                try:
+                    self.format = BytesParser.interpret_format_name(format)
+                except Exception:
+                    out(dbg("alias not found: %s" % format))
 
-            #exit when user-specified format not in both formats_rex and formats_aliases 
-            assert (format in BytesParser.formats_rex.keys() or self.format is not None), \
-                    "Format '%s' is not implemented." % format
+                #exit when user-specified format not in both formats_rex and formats_aliases 
+                assert (format in BytesParser.formats_rex.keys() or self.format is not None), \
+                        "Format '%s' is not implemented." % format
                     
             if self.format is None:
                 self.format = format

--- a/badchars.py
+++ b/badchars.py
@@ -102,14 +102,16 @@ class BytesParser():
 
         BytesParser.compile_regexps()
 
-        self.normalize_input()
+        #do not normalize input on raw format to prevent input tempering
+        if str(format).lower() != "raw":
+            self.normalize_input()
 
         if format:
             out(dbg("Using user-specified format: %s" % format))
 
             if str(format).lower() == "raw":
                 self.format = "raw"
-                           
+
             else:		
                 try:
                     self.format = BytesParser.interpret_format_name(format)


### PR DESCRIPTION
**##Problem:** 
badchar.py does not recognize "raw" as parameter for --format1, --format2

e.g,

```
> python badchars.py cmp.txt dump.txt -C --format2=raw

        :: BadChars.py (v:0.2) - Exploit Development Bad Characters hunting tool.
                Equipped with Corelan.be Mona's buffers comparison LCS-based algorithm

[+] good_buffer has been recognized as escaped-hexes formatted.
[+] Fetched 341 bytes successfully from good_buffer
Traceback (most recent call last):
  File "D:\resources\exploit dev\expdevBadChars\badchars.py", line 1028, in <module>
    sys.exit(main(sys.argv))
  File "D:\resources\exploit dev\expdevBadChars\badchars.py", line 961, in main
    buffers[1].extend(fetch_file(filenames[1], 'bad_buffer', options.format2))
  File "D:\resources\exploit dev\expdevBadChars\badchars.py", line 860, in fetch_file
    b = BytesParser(buff, name, format)
  File "D:\resources\exploit dev\expdevBadChars\badchars.py", line 117, in __init__
    "Format '%s' is not implemented." % format
AssertionError: Format 'raw' is not implemented.
```


On a separate note, i wonder what is format "byte-array"? any idea where can I get a dump in this format?
